### PR TITLE
Enhance Electron UI with Tailwind dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A minimal CLI tool that:
 2. Opens a browser window for your chosen puzzle.
 3. Overlays each puzzle piece with its load-order number.
 
+The included Electron GUI features a minimalist dark theme built with Tailwind CSS.
+
 ---
 
 ## Prerequisites
@@ -38,7 +40,7 @@ Run the CLI:
 node capture.js
 ```
 
-Or launch the GUI:
+Or launch the GUI (now styled with Tailwind CSS in dark mode):
 
 ```bash
 npm start

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,28 +1,32 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Jigsaw Planet Assistant</title>
-</head>
-<body>
-  <h1>Puzzles</h1>
-  <ul id="puzzleList"></ul>
+<html class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Jigsaw Planet Assistant</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-900 text-gray-100 min-h-screen flex items-center justify-center">
+    <main class="w-full max-w-md p-4">
+      <h1 class="text-xl font-semibold mb-4 text-center">Puzzles</h1>
+      <ul id="puzzleList" class="space-y-2"></ul>
+    </main>
 
-  <script>
-    window.electronAPI.getPuzzles().then(puzzles => {
-      const list = document.getElementById('puzzleList');
-      puzzles.forEach(p => {
-        const li = document.createElement('li');
-        const link = document.createElement('a');
-        link.href = '#';
-        link.textContent = p.title;
-        link.addEventListener('click', () => {
-          window.electronAPI.labelPuzzle(p.url);
+    <script>
+      window.electronAPI.getPuzzles().then(puzzles => {
+        const list = document.getElementById('puzzleList');
+        puzzles.forEach(p => {
+          const li = document.createElement('li');
+          const link = document.createElement('a');
+          link.href = '#';
+          link.className = 'block rounded bg-gray-800 hover:bg-gray-700 px-3 py-2';
+          link.textContent = p.title;
+          link.addEventListener('click', () => {
+            window.electronAPI.labelPuzzle(p.url);
+          });
+          li.appendChild(link);
+          list.appendChild(li);
         });
-        li.appendChild(link);
-        list.appendChild(li);
       });
-    });
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add Tailwind CSS via CDN and modern dark mode layout
- update README to mention Tailwind-styled GUI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bff6ed7e0832686b96d019e434b84