### PR TITLE
Fix puzzle piece counting

### DIFF
--- a/capture.js
+++ b/capture.js
@@ -64,7 +64,11 @@ async function labelPuzzle(selectedUrl) {
     Object.defineProperty(proto, 'src', {
       set(v) {
         const ret = desc.set.call(this, v);
-        if (typeof v === 'string' && v.startsWith('data:image/png;base64,')) {
+        if (
+          typeof v === 'string' &&
+          v.startsWith('data:image/png;base64,') &&
+          !this.dataset.pieceId
+        ) {
           const id = ++window._pieceCount;
           this.dataset.pieceId = id;
           window.inlinePieces.push({ id, time: performance.now() });


### PR DESCRIPTION
## Summary
- prevent multiple increments when assigning inline piece URLs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c0b737b008326bacd8943d9b5a8b1