### PR TITLE
Add loading resize warning

### DIFF
--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -41,6 +41,9 @@
       </div>
       <div id="puzzleLoading" class="space-y-2 hidden">
         <p id="currentPuzzleTitle" class="text-center text-gray-300"></p>
+        <p id="resizeWarning" class="text-center text-yellow-400 text-sm hidden">
+          Avoid resizing the window while the puzzle loads.
+        </p>
         <div class="progress-container w-full h-2 bg-neutral-700 rounded overflow-hidden">
           <div class="progress-bar w-full h-2 relative"></div>
         </div>
@@ -56,6 +59,7 @@
         const pickText = document.getElementById('pickText');
         const puzzleLoading = document.getElementById('puzzleLoading');
         const puzzleTitle = document.getElementById('currentPuzzleTitle');
+        const resizeWarning = document.getElementById('resizeWarning');
         loading.style.display = 'none';
         list.classList.remove('hidden');
         pickText.classList.remove('hidden');
@@ -69,11 +73,13 @@
             e.preventDefault();
             puzzleTitle.textContent = p.title;
             puzzleLoading.classList.remove('hidden');
+            resizeWarning.classList.remove('hidden');
             pickText.classList.add('hidden');
             list.classList.add('hidden');
             list.querySelectorAll('a').forEach(a => (a.style.pointerEvents = 'none'));
             await window.electronAPI.labelPuzzle(p.url);
             puzzleLoading.classList.add('hidden');
+            resizeWarning.classList.add('hidden');
             puzzleTitle.textContent = '';
             pickText.classList.remove('hidden');
             list.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- show a small message warning users not to resize the window while the puzzle loads

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c0f90a560832685bd71dc655a3406