### PR TITLE
Add Windows launcher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Launch the Electron GUI:
 npm start
 ```
 
+On Windows you can run the helper script instead:
+
+```powershell
+./start-jigsaw.ps1
+```
+
 In the GUI, click a puzzle title to open it in a new browser window. Each
 piece will be badged with its load-order ID. Press "L" to toggle badges and
 close the browser when done.

--- a/start-jigsaw.ps1
+++ b/start-jigsaw.ps1
@@ -1,0 +1,48 @@
+# Start Jigsaw Planet Assistant
+# This script verifies dependencies and launches the Electron GUI.
+
+Write-Host "=== Jigsaw Planet Assistant Launcher ===" -ForegroundColor Cyan
+
+function Install-Node {
+    Write-Host "Node.js not found. Attempting installation..." -ForegroundColor Yellow
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Host "Installing Node.js via winget" -ForegroundColor Yellow
+        winget install -e --id OpenJS.NodeJS.LTS
+    } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+        Write-Host "Installing Node.js via Chocolatey" -ForegroundColor Yellow
+        choco install nodejs -y
+    } else {
+        Write-Host "No package manager available to auto-install Node.js." -ForegroundColor Red
+        Write-Host "Please install Node.js from https://nodejs.org and run this script again." -ForegroundColor Red
+        exit 1
+    }
+}
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Install-Node
+} else {
+    $ver = node --version
+    Write-Host "Node.js $ver detected" -ForegroundColor Green
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Write-Host "npm was not found even after installing Node.js." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Checking npm packages" -ForegroundColor Cyan
+if (-not (Test-Path node_modules)) {
+    Write-Host "node_modules directory missing - running npm install" -ForegroundColor Yellow
+    npm install
+} else {
+    $npmStatus = npm ls --depth=0 2>&1
+    if ($npmStatus -match "missing") {
+        Write-Host "Some packages are missing - running npm install" -ForegroundColor Yellow
+        npm install
+    } else {
+        Write-Host "All packages are present" -ForegroundColor Green
+    }
+}
+
+Write-Host "Launching Electron GUI" -ForegroundColor Cyan
+npm start


### PR DESCRIPTION
## Summary
- add `start-jigsaw.ps1` for a verbose setup and launch on Windows
- document the PowerShell script in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c10f7c9288326a626357125e37a80