### PR TITLE
Load puzzles inside Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ On Windows you can also run:
 ./start-jigsaw.ps1
 ```
 
-Select a puzzle in the app to open it. Each piece displays its load number; press **L** to toggle these labels.
+Select a puzzle in the app to open it in a new Electron window. Each piece displays its load number; press **L** to toggle these labels.
 
 ## Troubleshooting
 
-If no puzzles load or Puppeteer times out, try raising the timeout values in `capture.js`.
+If no puzzles load, try raising the timeout values in `capture.js`. Puppeteer is still used only for scraping the puzzle list.
 
 ## Author
 

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
-const { scrapePuzzles, labelPuzzle } = require('../capture');
+const { scrapePuzzles } = require('../capture');
 
 async function createWindow() {
   const win = new BrowserWindow({
@@ -21,7 +21,15 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle('label-puzzle', async (_event, url) => {
-    await labelPuzzle(url);
+    const puzzleWin = new BrowserWindow({
+      width: 1024,
+      height: 768,
+      webPreferences: {
+        preload: path.join(__dirname, 'puzzlePreload.js'),
+      },
+    });
+
+    await puzzleWin.loadURL(url);
   });
 
   createWindow();

--- a/electron-app/puzzlePreload.js
+++ b/electron-app/puzzlePreload.js
@@ -1,0 +1,135 @@
+// electron-app/puzzlePreload.js
+
+window.inlinePieces = [];
+window._pieceCount = 0;
+
+(() => {
+  const proto = HTMLImageElement.prototype;
+  const desc = Object.getOwnPropertyDescriptor(proto, 'src');
+  Object.defineProperty(proto, 'src', {
+    set(v) {
+      const ret = desc.set.call(this, v);
+      if (
+        typeof v === 'string' &&
+        v.startsWith('data:image/png;base64,') &&
+        !this.dataset.pieceId
+      ) {
+        const id = ++window._pieceCount;
+        this.dataset.pieceId = id;
+        window.inlinePieces.push({ id, time: performance.now() });
+      }
+      return ret;
+    },
+    get() {
+      return desc.get.call(this);
+    },
+    configurable: true,
+    enumerable: true,
+  });
+})();
+
+window.addEventListener('DOMContentLoaded', () => {
+  const check = setInterval(() => {
+    if (document.querySelector('img[data-piece-id]')) {
+      clearInterval(check);
+      setTimeout(() => {
+        const start = Math.min(...window.inlinePieces.map(p => p.time));
+        const pieces = window.inlinePieces
+          .map(p => ({ id: p.id, t: (p.time - start).toFixed(1) }))
+          .sort((a, b) => a.t - b.t);
+
+        const labeledBadges = {};
+        const overlay = document.createElement('div');
+        overlay.id = 'badgeOverlay';
+        Object.assign(overlay.style, {
+          position: 'fixed',
+          top: '0',
+          left: '0',
+          width: '100%',
+          height: '100%',
+          pointerEvents: 'none',
+          zIndex: 99999,
+        });
+        document.body.appendChild(overlay);
+
+        function isInViewport(rect) {
+          return !(
+            rect.right < 0 ||
+            rect.bottom < 0 ||
+            rect.left > window.innerWidth ||
+            rect.top > window.innerHeight
+          );
+        }
+
+        for (const { id } of pieces) {
+          const img = document.querySelector(`img[data-piece-id="${id}"]`);
+          if (!img) continue;
+          const rect = img.getBoundingClientRect();
+          const badge = document.createElement('div');
+          badge.className = 'piece-num';
+          Object.assign(badge.style, {
+            position: 'absolute',
+            top: '0',
+            left: '0',
+            transform: `translate(${rect.left + 2}px, ${rect.top + 2}px)`,
+            background: 'rgba(0,0,0,0.6)',
+            color: '#fff',
+            fontSize: '10px',
+            fontWeight: 'bold',
+            padding: '2px 4px',
+            borderRadius: '3px',
+            pointerEvents: 'none',
+            zIndex: 100000,
+          });
+          badge.textContent = id;
+          overlay.appendChild(badge);
+          labeledBadges[id] = badge;
+        }
+
+        function updateBadges() {
+          for (const pieceId in labeledBadges) {
+            const img = document.querySelector(`img[data-piece-id="${pieceId}"]`);
+            if (!img) {
+              labeledBadges[pieceId].style.display = 'none';
+              continue;
+            }
+            const rect = img.getBoundingClientRect();
+            const badge = labeledBadges[pieceId];
+            if (!isInViewport(rect)) {
+              badge.style.display = 'none';
+              continue;
+            } else {
+              badge.style.display = 'block';
+            }
+            badge.style.transform = `translate(${rect.left + 2}px, ${rect.top + 2}px)`;
+          }
+          requestAnimationFrame(updateBadges);
+        }
+        requestAnimationFrame(updateBadges);
+
+        let resizeTimeout = null;
+        window.addEventListener('resize', () => {
+          if (resizeTimeout) clearTimeout(resizeTimeout);
+          resizeTimeout = setTimeout(() => {
+            for (const pieceId in labeledBadges) {
+              const img = document.querySelector(`img[data-piece-id="${pieceId}"]`);
+              if (!img) continue;
+              const rect = img.getBoundingClientRect();
+              const badge = labeledBadges[pieceId];
+              badge.style.transform = `translate(${rect.left + 2}px, ${rect.top + 2}px)`;
+            }
+          }, 100);
+        });
+
+        let badgesVisible = true;
+        document.addEventListener('keydown', e => {
+          if (e.key.toLowerCase() === 'l') {
+            badgesVisible = !badgesVisible;
+            overlay.style.display = badgesVisible ? 'block' : 'none';
+          }
+        });
+      }, 2000);
+    }
+  }, 100);
+});
+


### PR DESCRIPTION
## Summary
- create `puzzlePreload.js` to inject labeling logic for puzzle pieces
- open puzzles in a new Electron `BrowserWindow` instead of launching Puppeteer
- document the new behaviour in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684da72b7ab083268c5a337c80d1c758