### PR TITLE
Update puzzle window contextIsolation

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -26,6 +26,7 @@ app.whenReady().then(() => {
       height: 768,
       webPreferences: {
         preload: path.join(__dirname, 'puzzlePreload.js'),
+        contextIsolation: false,
       },
     });
 


### PR DESCRIPTION
## Summary
- configure `puzzleWin` to disable context isolation
- confirm puzzlePreload still avoids Node APIs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684daa7cf3e88326b4eab9c0f76559d3