### PR TITLE
Open puzzle in same window

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -20,17 +20,13 @@ app.whenReady().then(() => {
     return puzzles;
   });
 
-  ipcMain.handle('label-puzzle', async (_event, url) => {
-    const puzzleWin = new BrowserWindow({
-      width: 1024,
-      height: 768,
-      webPreferences: {
-        preload: path.join(__dirname, 'puzzlePreload.js'),
-        contextIsolation: false,
-      },
-    });
-
-    await puzzleWin.loadURL(url);
+  ipcMain.handle('label-puzzle', async (event, url) => {
+    // Load the selected puzzle in the existing window instead of opening
+    // a new one. puzzlePreload.js will be injected by preload.js when the
+    // window navigates to jigsawplanet.com, keeping everything in a single
+    // window.
+    const win = BrowserWindow.fromWebContents(event.sender);
+    await win.loadURL(url);
   });
 
   createWindow();

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -1,6 +1,18 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
+const path = require('path');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getPuzzles: () => ipcRenderer.invoke('get-puzzles'),
   labelPuzzle: url => ipcRenderer.invoke('label-puzzle', url),
 });
+
+// When navigating to a jigsawplanet.com puzzle, inject the overlay code that
+// was previously provided by puzzlePreload.js. Evaluating the file here keeps
+// everything working when the same window loads the puzzle page.
+if (location.hostname.includes('jigsawplanet.com')) {
+  const preloadPath = path.join(__dirname, 'puzzlePreload.js');
+  const script = fs.readFileSync(preloadPath, 'utf8');
+  // Execute the preload script in this context
+  require('vm').runInThisContext(script, { filename: 'puzzlePreload.js' });
+}


### PR DESCRIPTION
## Summary
- reuse the current Electron window for puzzle pages
- inject puzzle overlay script from `preload.js`
- document the same-window navigation in a comment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684daba6ee808326b3b57b93a6b4c959